### PR TITLE
Linux/R-Pi ARM build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 ### DroidCam OBS
 
 https://www.dev47apps.com/obs/
+
+# Compiling for Linux aarch64/ARMv8 64bit (Tested on with a Raspberry Pi 4 on Ubuntu 21.10)
+
+```
+sudo apt install libturbojpeg
+sudo apt install libusbmuxd-dev
+sudo apt install libobs-dev
+sudo apt install libavcodec-dev
+mkdir build
+```
+
+in the Makefile change the JPEG_LIB folder to be where libturbojpeg.a resides.  
+`JPEG_LIB  = /usr/lib/aarch64-linux-gnu`


### PR DESCRIPTION
Runs great with `MESA_GL_VERSION_OVERRIDE=3.3 obs`


[droidcam-obs-aarch64-linux-gnu.zip](https://github.com/dev47apps/droidcam-obs-plugin/files/7648482/droidcam-obs.zip)