### PR TITLE
Use `-limobiledevice-1.0` on Fedora

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -24,7 +24,7 @@ else
 	LDD_DIRS += -L$(IMOBILEDEV_LIB)
 
 	LDD_LIBS += -lturbojpeg
-	LDD_LIBS += -limobiledevice
+	LDD_LIBS += -limobiledevice-1.0
 endif
 
 INCLUDES += -I$(IMOBILEDEV_DIR)/include


### PR DESCRIPTION
Not expecting this to be merged, just wanted to let you know. I don't know what the best way to support multiple, conflicting `LDD_LIBS` is, using `pkg-config` as you comment in the code, I imagine.

I'm compiling on Fedora, because that's the new flagship distro for Asahi Linux, the project to get Linux on the new Apple Silicon machines (M1/M2 MacBooks etc). And none of them have Webcam support yet, hence DroidCam to the rescue!