### PR TITLE
Linux:  Fixes for missing obs-ffmpeg-compat.h

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -16,6 +16,10 @@ JPEG_LIB ?= $(JPEG_DIR)/lib$(shell getconf LONG_BIT)
 LIBOBS_INCLUDES ?= /usr/include/obs
 FFMPEG_INCLUDES ?= /usr/include/ffmpeg
 
+# dynamic linking library names
+LIBTURBOJPEG_DYN_NAME ?= libturbojpeg
+LIBUSBMUXD_DYN_NAME ?= libusbmuxd
+LIBIMOBILEDEV_DYN_NAME ?= libimobiledevice
 
 #
 define ADD_Lib =
@@ -34,9 +38,9 @@ ifeq "$(ALLOW_STATIC)" "yes"
 	STATIC += $(IMOBILEDEV_LIB)/libplist-2.0.a
 
 else
-$(eval	$(call ADD_Lib,libturbojpeg))
-	LDD_LIBS += -limobiledevice-1.0
-$(eval	$(call ADD_Lib,libusbmuxd))
+$(eval	$(call ADD_Lib,$(LIBTURBOJPEG_DYN_NAME)))
+$(eval	$(call ADD_Lib,$(LIBUSBMUXD_DYN_NAME)))
+$(eval	$(call ADD_Lib,$(LIBIMOBILEDEV_DYN_NAME)))
 endif
 
 ifdef DROIDCAM_OVERRIDE
@@ -53,4 +57,4 @@ INCLUDES += -I$(LIBOBS_INCLUDES)
 INCLUDES += -I$(FFMPEG_INCLUDES)
 
 LDD_LIBS += -lobs
-LDD_FLAG += $(LDFLAGS) -shared
+LDD_FLAG += -shared

--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -35,6 +35,7 @@ ifeq "$(ALLOW_STATIC)" "yes"
 
 else
 $(eval	$(call ADD_Lib,libturbojpeg))
+	LDD_LIBS += -limobiledevice-1.0
 $(eval	$(call ADD_Lib,libusbmuxd))
 endif
 
@@ -52,4 +53,4 @@ INCLUDES += -I$(LIBOBS_INCLUDES)
 INCLUDES += -I$(FFMPEG_INCLUDES)
 
 LDD_LIBS += -lobs
-LDD_FLAG += -shared
+LDD_FLAG += $(LDFLAGS) -shared

--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -17,9 +17,9 @@ LIBOBS_INCLUDES ?= /usr/include/obs
 FFMPEG_INCLUDES ?= /usr/include/ffmpeg
 
 # dynamic linking library names
-LIBTURBOJPEG_DYN_NAME ?= libturbojpeg
-LIBUSBMUXD_DYN_NAME ?= libusbmuxd
-LIBIMOBILEDEV_DYN_NAME ?= libimobiledevice
+LIBTURBOJPEG ?= libturbojpeg
+LIBUSBMUXD ?= libusbmuxd
+LIBIMOBILEDEV ?= libimobiledevice
 
 #
 define ADD_Lib =
@@ -38,9 +38,9 @@ ifeq "$(ALLOW_STATIC)" "yes"
 	STATIC += $(IMOBILEDEV_LIB)/libplist-2.0.a
 
 else
-$(eval	$(call ADD_Lib,$(LIBTURBOJPEG_DYN_NAME)))
-$(eval	$(call ADD_Lib,$(LIBUSBMUXD_DYN_NAME)))
-$(eval	$(call ADD_Lib,$(LIBIMOBILEDEV_DYN_NAME)))
+$(eval	$(call ADD_Lib,$(LIBTURBOJPEG)))
+$(eval	$(call ADD_Lib,$(LIBUSBMUXD)))
+$(eval	$(call ADD_Lib,$(LIBIMOBILEDEV)))
 endif
 
 ifdef DROIDCAM_OVERRIDE

--- a/src/ffmpeg_decode.cc
+++ b/src/ffmpeg_decode.cc
@@ -18,7 +18,6 @@
 
 #include "plugin.h"
 #include "ffmpeg_decode.h"
-#include <obs-ffmpeg-compat.h>
 #include <libavutil/channel_layout.h>
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
@@ -305,7 +304,7 @@ static inline enum speaker_layout convert_speaker_layout(int channels)
 
 DataPacket* FFMpegDecoder::pull_empty_packet(size_t size)
 {
-	size_t new_size = size + INPUT_BUFFER_PADDING_SIZE;
+	size_t new_size = size + AV_INPUT_BUFFER_PADDING_SIZE;
 	DataPacket* packet = Decoder::pull_empty_packet(new_size);
 	memset(packet->data, 0, new_size);
 	return packet;


### PR DESCRIPTION
Hi, I maintain the [droidcam-obs-plugin ArchLinux User Repository (AUR) Package](https://aur.archlinux.org/packages/droidcam-obs-plugin).  I recently tried to update said AUR package to the current version 2.3.3 and was getting a build failure:

```
src/ffmpeg_decode.cc:21:10: fatal error: obs-ffmpeg-compat.h: No such file or directory
   21 | #include <obs-ffmpeg-compat.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Upon inspecting /usr/include/obs I noticed that around OBS Version 30.2.0 the /usr/include/obs/obs-ffmpeg-compat.h file is no longer being included in the builds (at least the builds provided by the [AUR obs-studio-tytan652 package](https://aur.archlinux.org/packages/obs-studio-tytan652)).

After removing line 21 from `src/ffmpeg_decode.c` I saw the following error:

```
src/ffmpeg_decode.cc: In member function ‘DataPacket* FFMpegDecoder::pull_empty_packet(size_t)’:
src/ffmpeg_decode.cc:307:34: error: ‘INPUT_BUFFER_PADDING_SIZE’ was not declared in this scope; did you mean ‘AV_INPUT_BUFFER_PADDING_SIZE’?
  307 |         size_t new_size = size + INPUT_BUFFER_PADDING_SIZE;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                  AV_INPUT_BUFFER_PADDING_SIZE
```

This error kind of clued me into the fact that `AV_INPUT_BUFFER_PADDING_SIZE` is probably the newer FFMPEG equivalent of the `INPUT_BUFFER_PADDING_SIZE` constant originally defined in the old `/usr/include/obs/obs-ffmpeg-compat.h` file.

One last note:  To get this to build on ArchLinux the dependency on `libmobiledevice-1.0` was also needed (that has been a part of a patch that is in the AUR package since before I started to maintain the package).

Hoping I got this right.  The package does appear to function within OBS on my ArchLinux system after these tweaks to get the package to build.

#### src/ffmpeg_decode.cc:

It appears the latest linux obs builds no longer include
`/usr/include/obs/obs-ffmpeg-compat.h`.

I believe that `AV_INPUT_BUFFER_PADDING_SIZE` is the replacement for
the old `INPUT_BUFFER_PADDING_SIZE` that used to be defined within
`obs-ffmpeg-compat.h`.

#### linux/linux.mk:

It also seems (on Linux) that there needs to be a dependency on `libmobiledevice-1.0`.