### PR TITLE
Port GUI code to Qt 6

### DIFF
--- a/linux/gui.mk
+++ b/linux/gui.mk
@@ -1,15 +1,17 @@
 
 ifdef DROIDCAM_OVERRIDE
+MOC      ?= /usr/lib/qt6/moc
+UIC      ?= /usr/lib/qt6/uic
 INCLUDES += -Isrc/ui
 SRC      += src/ui/AddDevice.cpp
 SRC      += src/ui/moc_AddDevice.cpp
 SRC      += src/ui/uic_AddDevice.h
 
 src/ui/uic_AddDevice.h: src/ui/AddDevice.ui
-	uic -o $@ $^
+	$(UIC) -o $@ $^
 
 src/ui/moc_AddDevice.cpp: src/ui/AddDevice.h
-	moc -o $@ $^
+	$(MOC) -o $@ $^
 
 .PHONY: install
 install: /opt/droidcam-obs-client/bin/64bit/droidcam
@@ -18,8 +20,9 @@ install: /opt/droidcam-obs-client/bin/64bit/droidcam
 
 endif
 
-$(eval $(call ADD_Lib,Qt5Core))
-$(eval $(call ADD_Lib,Qt5Gui))
-$(eval $(call ADD_Lib,Qt5Svg))
-$(eval $(call ADD_Lib,Qt5Widgets))
+$(eval $(call ADD_Lib,Qt6Core))
+$(eval $(call ADD_Lib,Qt6Gui))
+$(eval $(call ADD_Lib,Qt6Svg))
+$(eval $(call ADD_Lib,Qt6SvgWidgets))
+$(eval $(call ADD_Lib,Qt6Widgets))
 


### PR DESCRIPTION
OBS Studio has been using Qt 6 for some time, and dropped support for Qt 5 as well since it is EOL. Trivially migrate to Qt 6 so that we do not depend on it anymore.