### PR TITLE
Added support for libavcodec 62

### DIFF
--- a/src/ffmpeg_decode.cc
+++ b/src/ffmpeg_decode.cc
@@ -120,7 +120,7 @@ int FFMpegDecoder::init(uint8_t* header, enum AVCodecID id, bool use_hw)
 		}
 
 		decoder->sample_rate = aac_frequencies[sr_idx];
-		decoder->profile = AV_PROFILE_AAC_LOW;
+		decoder->profile = FF_PROFILE_AAC_LOW;
 
 		const int channels = (header[1] >> 3) & 0xF;
 		#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)

--- a/src/ffmpeg_decode.cc
+++ b/src/ffmpeg_decode.cc
@@ -120,7 +120,11 @@ int FFMpegDecoder::init(uint8_t* header, enum AVCodecID id, bool use_hw)
 		}
 
 		decoder->sample_rate = aac_frequencies[sr_idx];
-		decoder->profile = FF_PROFILE_AAC_LOW;
+		#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(62, 0, 0)
+    	decoder->profile = FF_PROFILE_AAC_LOW;
+		#else
+    	decoder->profile = AV_PROFILE_AAC_LOW;
+		#endif
 
 		const int channels = (header[1] >> 3) & 0xF;
 		#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)

--- a/src/ffmpeg_decode.cc
+++ b/src/ffmpeg_decode.cc
@@ -120,7 +120,7 @@ int FFMpegDecoder::init(uint8_t* header, enum AVCodecID id, bool use_hw)
 		}
 
 		decoder->sample_rate = aac_frequencies[sr_idx];
-		decoder->profile = FF_PROFILE_AAC_LOW;
+		decoder->profile = AV_PROFILE_AAC_LOW;
 
 		const int channels = (header[1] >> 3) & 0xF;
 		#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -106,12 +106,6 @@ bool obs_module_load(void) {
     memset(os_name_version, 0, sizeof(os_name_version));
     memset(&droidcam_obs_info, 0, sizeof(struct obs_source_info));
 
-    if (AV_VERSION_MAJOR(avcodec_version()) > LIBAVCODEC_VERSION_MAJOR) {
-        blog(LOG_ERROR, "[droidcam-obs] libavcodec version %u is too high (<= %d required for this release).",
-            AV_VERSION_MAJOR(avcodec_version()), LIBAVCODEC_VERSION_MAJOR);
-        return false;
-    }
-
     droidcam_obs_info.id           = "droidcam_obs";
     droidcam_obs_info.type         = OBS_SOURCE_TYPE_INPUT;
     droidcam_obs_info.output_flags = OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_AUDIO | OBS_SOURCE_ASYNC_VIDEO;

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -106,6 +106,12 @@ bool obs_module_load(void) {
     memset(os_name_version, 0, sizeof(os_name_version));
     memset(&droidcam_obs_info, 0, sizeof(struct obs_source_info));
 
+    if (AV_VERSION_MAJOR(avcodec_version()) > LIBAVCODEC_VERSION_MAJOR) {
+        blog(LOG_ERROR, "[droidcam-obs] libavcodec version %u is too high (<= %d required for this release).",
+            AV_VERSION_MAJOR(avcodec_version()), LIBAVCODEC_VERSION_MAJOR);
+        return false;
+    }
+
     droidcam_obs_info.id           = "droidcam_obs";
     droidcam_obs_info.type         = OBS_SOURCE_TYPE_INPUT;
     droidcam_obs_info.output_flags = OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_AUDIO | OBS_SOURCE_ASYNC_VIDEO;


### PR DESCRIPTION
**Changes:**
- Changed the deprecated `FF_PROFILE_AAC_LOW` to `AV_PROFILE_AAC_LOW`
- Removed an avcodec version check to allow compatibility with libavcodec 62

**Tested on:**
Arch Linux with libavcodec 62 and OBS Studio 32.0.1. Plugin loads and functions as expected.